### PR TITLE
WIP: Add test to check failure when cannot create output directory

### DIFF
--- a/test/unit/reporters/markdown-reporter-test.coffee
+++ b/test/unit/reporters/markdown-reporter-test.coffee
@@ -2,15 +2,16 @@
 sinon = require 'sinon'
 proxyquire = require('proxyquire').noCallThru()
 
-
 {EventEmitter} = require 'events'
-fsStub = require 'fs'
-mkdirpStub = sinon.spy((path, cb) -> cb())
 loggerStub = require '../../../src/logger'
+fsStub = require 'fs'
+mkdirpStub = sinon.spy((path, cb) => cb())
+mkdirpProxy = (path, cb) -> mkdirpStub(path, cb)
+
 MarkdownReporter = proxyquire '../../../src/reporters/markdown-reporter', {
   './../logger' : loggerStub
-  'fs': fsStub
-  'mkdirp': mkdirpStub
+  'fs' : fsStub
+  'mkdirp' : mkdirpProxy
 }
 
 describe 'MarkdownReporter', () ->
@@ -92,6 +93,23 @@ describe 'MarkdownReporter', () ->
       assert.isOk mkdirpStub.called
       assert.isOk fsStub.writeFile.called
       done()
+
+    describe 'when cannot create output directory', () ->
+
+      beforeEach () ->
+        sinon.stub loggerStub, 'error'
+        mkdirpStub = sinon.spy((path, cb) => cb('error'))
+
+      after () ->
+        loggerStub.error.restore()
+        mkdirpStub = sinon.spy((path, cb) => cb())
+
+      it 'should write to log', (done) ->
+        emitter.emit 'end', () ->
+          assert.isOk mkdirpStub.called
+          assert.isOk fsStub.writeFile.notCalled
+          assert.isOk loggerStub.error.called
+          done()
 
   describe 'when test passes', () ->
 

--- a/test/unit/reporters/x-unit-reporter-test.coffee
+++ b/test/unit/reporters/x-unit-reporter-test.coffee
@@ -7,8 +7,9 @@ loggerStub = require '../../../src/logger'
 fsStub = require 'fs'
 mkdirpStub = sinon.spy((path, cb) => cb())
 mkdirpProxy = (path, cb) -> mkdirpStub(path, cb)
+
 XUnitReporter = proxyquire '../../../src/reporters/x-unit-reporter', {
-  './../logger' : loggerStub,
+  './../logger' : loggerStub
   'fs' : fsStub
   'mkdirp' : mkdirpProxy
 }
@@ -83,7 +84,7 @@ describe 'XUnitReporter', () ->
 
       after () ->
         loggerStub.error.restore()
-         mkdirpStub = sinon.spy((path, cb) => cb())
+        mkdirpStub = sinon.spy((path, cb) => cb())
 
       it 'should write to log', (done) ->
         emitter = new EventEmitter()

--- a/test/unit/reporters/x-unit-reporter-test.coffee
+++ b/test/unit/reporters/x-unit-reporter-test.coffee
@@ -6,10 +6,11 @@ proxyquire = require('proxyquire').noCallThru()
 loggerStub = require '../../../src/logger'
 fsStub = require 'fs'
 mkdirpStub = sinon.spy((path, cb) => cb())
+mkdirpProxy = (path, cb) -> mkdirpStub(path, cb)
 XUnitReporter = proxyquire '../../../src/reporters/x-unit-reporter', {
   './../logger' : loggerStub,
   'fs' : fsStub
-  'mkdirp' : mkdirpStub
+  'mkdirp' : mkdirpProxy
 }
 
 describe 'XUnitReporter', () ->
@@ -73,6 +74,25 @@ describe 'XUnitReporter', () ->
         assert.isOk mkdirpStub.called
         assert.isOk fsStub.appendFileSync.called
         done()
+
+    describe 'when cannot create output directory', () ->
+
+      beforeEach () ->
+        sinon.stub loggerStub, 'error'
+        mkdirpStub = sinon.spy((path, cb) => cb('error'))
+
+      after () ->
+        loggerStub.error.restore()
+         mkdirpStub = sinon.spy((path, cb) => cb())
+
+      it 'should write to log', (done) ->
+        emitter = new EventEmitter()
+        xUnitReporter = new XUnitReporter(emitter, {}, {}, "test.xml")
+        emitter.emit 'start', '', () ->
+          assert.isOk mkdirpStub.called
+          assert.isOk fsStub.appendFileSync.notCalled
+          assert.isOk loggerStub.error.called
+          done()
 
   describe 'when ending', () ->
 


### PR DESCRIPTION
#### :rocket: Why this change?

To increase the test coverage when cannot create the output directory.

I did a proxy of the mkdirpStub to change the behaviour during the test. This is just my first try, I don't know Coffescript neither Mocha, so maybe all is wrong (I'm sorry 😅).

If you like the change, don't merge this pull request and I will repeat the same change in the rest of the reporters.

#### :memo: Related issues and Pull Requests

Improve test coverage in #899

#### :white_check_mark: What didn't I forget?

- [x] To write docs
- [x] To write tests
- [x] To put [Conventional Changelog](https://dredd.readthedocs.io/en/latest/contributing/#sem-rel) prefixes in front of all my commits and run `npm run lint`
